### PR TITLE
Fix to enforce strong typing for attach_policy_arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check the [examples](examples) directory.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | name | Name of the IAM user | string | n/a | yes |
-| attach\_policy\_arns | Existing policy ARNs to attach to the IAM user | list | `[]` | no |
+| attach\_policy\_arns | Existing policy ARNs to attach to the IAM user | list(string) | `[]` | no |
 | custom\_policies | Custom policies to create and attach to the IAM user | list | `[]` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `"true"` | no |
 | inline\_policies | Inline defined policies to attach to the IAM user | list | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,7 @@ variable "custom_policies" {
 
 variable "attach_policy_arns" {
   description = "Existing policy ARNs to attach to the IAM user"
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
## What

Add type to `attach_policy_arns`

## Why

It currently breaks as a list with a single item is parsed as a list of chars.