### PR TITLE
Fix the variable definition type for custom_policies

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,13 @@ variable "inline_policies" {
 variable "custom_policies" {
   description = "Custom policies to create and attach to the IAM user"
   default     = []
+  type = list(object({
+    name = string
+    statements = list(object({
+      actions   = list(string)
+      resources = list(string)
+    }))
+  }))
 }
 
 variable "attach_policy_arns" {


### PR DESCRIPTION
Why is it necessary? (Bug fix, feature, improvements?)
- TF errors out when creating custom policies to attach to the IAM user.

How does the change address the issue?
- Policy structures should be the same as inline policies - they're just
  created as separate policies and attached to IAM user instead of created
  on the IAM user.

What side effects does this change have?
- none